### PR TITLE
Show images produced by pediatric_airway_atlas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,6 @@ set(Slicer_QTSCRIPTEDMODULES_DISABLED
   Endoscopy
   LabelStatistics
   PerformanceTests
-  SampleData
   VectorToScalarVolume
   )
 

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -2,7 +2,7 @@ import logging
 import qt
 import slicer
 import slicer.ScriptedLoadableModule
-import slicer.util.VTKObservationMixin
+import slicer.util
 
 # from Resources import HomeResourcesResources
 
@@ -107,8 +107,10 @@ class HomeWidget(
         self.CustomToolBar.name = "CustomToolBar"
         slicer.util.mainWindow().insertToolBar(mainToolBar, self.CustomToolBar)
 
-        #     central = slicer.util.findChild(slicer.util.mainWindow(), name='CentralWidget')
-        #     central.setStyleSheet("background-color: #464449")
+        # centralaa = slicer.util.findChild(
+        #     slicer.util.mainWindow(), name="CentralWidget"
+        # )
+        # central.setStyleSheet("background-color: #464449")
 
         gearIcon = qt.QIcon(self.resourcePath("Icons/Gears.png"))
         self.settingsAction = self.CustomToolBar.addAction(gearIcon, "")
@@ -168,8 +170,9 @@ class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
 
     def exitApplication(self, status=slicer.util.EXIT_SUCCESS, message=None):
         """Exit application.
-        If ``status`` is ``slicer.util.EXIT_SUCCESS``, ``message`` is logged using ``logging.info(message)``
-        otherwise it is logged using ``logging.error(message)``.
+        If ``status`` is ``slicer.util.EXIT_SUCCESS``, ``message`` is logged using
+        ``logging.info(message)`` otherwise it is logged using
+        ``logging.error(message)``.
         """
 
         def _exitApplication():
@@ -199,7 +202,8 @@ class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
             sliceWidget = slicer.app.layoutManager().sliceWidget(name)
             self.setupSliceViewer(sliceWidget)
 
-        # Set linked slice views  in all existing slice composite nodes and in the default node
+        # Set linked slice views in all existing slice composite nodes and in the
+        # default node
         sliceCompositeNodes = slicer.util.getNodesByClass("vtkMRMLSliceCompositeNode")
         defaultSliceCompositeNode = slicer.mrmlScene.GetDefaultNodeByClass(
             "vtkMRMLSliceCompositeNode"
@@ -208,9 +212,9 @@ class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
             defaultSliceCompositeNode = slicer.mrmlScene.CreateNodeByClass(
                 "vtkMRMLSliceCompositeNode"
             )
-            defaultSliceCompositeNode.UnRegister(
-                None
-            )  # CreateNodeByClass is factory method, need to unregister the result to prevent memory leaks
+            # CreateNodeByClass is factory method, need to unregister the result to
+            # prevent memory leaks:
+            defaultSliceCompositeNode.UnRegister(None)
             slicer.mrmlScene.AddDefaultNode(defaultSliceCompositeNode)
         sliceCompositeNodes.append(defaultSliceCompositeNode)
         for sliceCompositeNode in sliceCompositeNodes:
@@ -234,7 +238,8 @@ class HomeTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be enough."""
+        """Do whatever is needed to reset the state - typically a scene clear will be
+        enough."""
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -156,21 +156,15 @@ class HomeWidget(
 
     def onVPAWVisualizeButton(self):
         """
-        Run processing when user clicks "VPAW Visualize" button.
+        Switch to the "VPAW Visualize" module when the user clicks the button.
         """
-        with slicer.util.tryWithErrorDisplay(
-            "Failed to compute results.", waitCursor=True
-        ):
-            slicer.util.selectModule("VPAWVisualize")
+        slicer.util.selectModule("VPAWVisualize")
 
     def onVPAWModelButton(self):
         """
-        Run processing when user clicks "VPAW Model" button.
+        Switch to the "VPAW Model" module when the user clicks the button.
         """
-        with slicer.util.tryWithErrorDisplay(
-            "Failed to compute results.", waitCursor=True
-        ):
-            slicer.util.selectModule("VPAWModel")
+        slicer.util.selectModule("VPAWModel")
 
 
 class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):

--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -64,6 +64,10 @@ class HomeWidget(
         # Apply style
         self.applyApplicationStyle()
 
+        # Buttons
+        self.ui.VPAWVisualizeButton.connect("clicked(bool)", self.onVPAWVisualizeButton)
+        self.ui.VPAWModelButton.connect("clicked(bool)", self.onVPAWModelButton)
+
     def setupNodes(self):
         # Set up the layout / 3D View
         self.logic.setup3DView()
@@ -149,6 +153,24 @@ class HomeWidget(
             style = fh.read()
             for widget in widgets:
                 widget.styleSheet = style
+
+    def onVPAWVisualizeButton(self):
+        """
+        Run processing when user clicks "VPAW Visualize" button.
+        """
+        with slicer.util.tryWithErrorDisplay(
+            "Failed to compute results.", waitCursor=True
+        ):
+            slicer.util.selectModule("VPAWVisualize")
+
+    def onVPAWModelButton(self):
+        """
+        Run processing when user clicks "VPAW Model" button.
+        """
+        with slicer.util.tryWithErrorDisplay(
+            "Failed to compute results.", waitCursor=True
+        ):
+            slicer.util.selectModule("VPAWModel")
 
 
 class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):

--- a/Modules/Scripted/Home/Resources/UI/Home.ui
+++ b/Modules/Scripted/Home/Resources/UI/Home.ui
@@ -10,7 +10,34 @@
     <height>434</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout"/>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPushButton" name="VPAWVisualizeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>VPAW Visualize</string>
+     </property>
+     <property name="text">
+      <string>VPAW Visualize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="VPAWModelButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>VPAW Model</string>
+     </property>
+     <property name="text">
+      <string>VPAW Model</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/Modules/Scripted/Home/Resources/UI/Home.ui
+++ b/Modules/Scripted/Home/Resources/UI/Home.ui
@@ -17,10 +17,10 @@
       <bool>true</bool>
      </property>
      <property name="toolTip">
-      <string>VPAW Visualize</string>
+      <string>Go to VPAW Visualize module</string>
      </property>
      <property name="text">
-      <string>VPAW Visualize</string>
+      <string>Go to VPAW Visualize module</string>
      </property>
     </widget>
    </item>
@@ -30,12 +30,25 @@
       <bool>true</bool>
      </property>
      <property name="toolTip">
-      <string>VPAW Model</string>
+      <string>Go to VPAW Model module</string>
      </property>
      <property name="text">
-      <string>VPAW Model</string>
+      <string>Go to VPAW Model module</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -12,35 +12,35 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPushButton" name="HomeButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Home</string>
-     </property>
-     <property name="text">
-      <string>Home</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="VPAWVisualizeButton">
      <property name="enabled">
       <bool>true</bool>
      </property>
      <property name="toolTip">
-      <string>VPAW Visualize</string>
+      <string>Go to VPAW Visualize module</string>
      </property>
      <property name="text">
-      <string>VPAW Visualize</string>
+      <string>Go to VPAW Visualize module</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="HomeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Go to Home module</string>
+     </property>
+     <property name="text">
+      <string>Go to Home module</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
-      <string>Inputs</string>
+      <string>VPAW Model: Inputs</string>
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="0" column="0">

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -12,6 +12,32 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QPushButton" name="HomeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Home</string>
+     </property>
+     <property name="text">
+      <string>Home</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="VPAWVisualizeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>VPAW Visualize</string>
+     </property>
+     <property name="text">
+      <string>VPAW Visualize</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
       <string>Inputs</string>

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -140,6 +140,8 @@ class VPAWModelWidget(
         )
 
         # Buttons
+        self.ui.HomeButton.connect("clicked(bool)", self.onHomeButton)
+        self.ui.VPAWVisualizeButton.connect("clicked(bool)", self.onVPAWVisualizeButton)
         self.ui.applyButton.connect("clicked(bool)", self.onApplyButton)
 
         # Make sure parameter node is initialized (needed for module reload)
@@ -311,6 +313,24 @@ class VPAWModelWidget(
         )
 
         self._parameterNode.EndModify(wasModified)
+
+    def onHomeButton(self):
+        """
+        Run processing when user clicks "Home" button.
+        """
+        with slicer.util.tryWithErrorDisplay(
+            "Failed to compute results.", waitCursor=True
+        ):
+            slicer.util.selectModule("Home")
+
+    def onVPAWVisualizeButton(self):
+        """
+        Run processing when user clicks "VPAW Visualize" button.
+        """
+        with slicer.util.tryWithErrorDisplay(
+            "Failed to compute results.", waitCursor=True
+        ):
+            slicer.util.selectModule("VPAWVisualize")
 
     def onApplyButton(self):
         """

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -1,7 +1,7 @@
 import logging
 import slicer
 import slicer.ScriptedLoadableModule
-import slicer.util.VTKObservationMixin
+import slicer.util
 import vtk
 
 
@@ -29,7 +29,8 @@ class VPAWModel(slicer.ScriptedLoadableModule.ScriptedLoadableModule):
             "Ebrahim Ebrahim (Kitware, Inc.)",
             "Lee Newberg (Kitware, Inc.)",
         ]
-        # TODO: update with short description of the module and a link to online module documentation
+        # TODO: update with short description of the module and a link to online module
+        # documentation
         self.parent.helpText = """
 This is the scripted loadable module named VPAW Model.  See more information in
 <a href="https://github.com/KitwareMedical/vpaw#VPAWModel">module documentation</a>.
@@ -82,9 +83,8 @@ class VPAWModelWidget(
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget.__init__(
             self, parent
         )
-        slicer.util.VTKObservationMixin.__init__(
-            self
-        )  # needed for parameter node observation
+        # needed for parameter node observation:
+        slicer.util.VTKObservationMixin.__init__(self)
         self.logic = None
         self._parameterNode = None
         self._updatingGUIFromParameterNode = False

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -316,21 +316,15 @@ class VPAWModelWidget(
 
     def onHomeButton(self):
         """
-        Run processing when user clicks "Home" button.
+        Switch to the "Home" module when the user clicks the button.
         """
-        with slicer.util.tryWithErrorDisplay(
-            "Failed to compute results.", waitCursor=True
-        ):
-            slicer.util.selectModule("Home")
+        slicer.util.selectModule("Home")
 
     def onVPAWVisualizeButton(self):
         """
-        Run processing when user clicks "VPAW Visualize" button.
+        Switch to the "VPAW Visualize" module when the user clicks the button.
         """
-        with slicer.util.tryWithErrorDisplay(
-            "Failed to compute results.", waitCursor=True
-        ):
-            slicer.util.selectModule("VPAWVisualize")
+        slicer.util.selectModule("VPAWVisualize")
 
     def onApplyButton(self):
         """

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -17,10 +17,10 @@
       <bool>true</bool>
      </property>
      <property name="toolTip">
-      <string>Home</string>
+      <string>Go to Home module</string>
      </property>
      <property name="text">
-      <string>Home</string>
+      <string>Go to Home module</string>
      </property>
     </widget>
    </item>
@@ -30,17 +30,17 @@
       <bool>true</bool>
      </property>
      <property name="toolTip">
-      <string>VPAW Model</string>
+      <string>Go to VPAW Model module</string>
      </property>
      <property name="text">
-      <string>VPAW Model</string>
+      <string>Go to VPAW Model module</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
-      <string>Patient Browser</string>
+      <string>VPAW Visualize: Inputs</string>
      </property>
      <property name="collapsed">
       <bool>false</bool>
@@ -74,7 +74,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="applyButton">
+    <widget class="QPushButton" name="showButton">
      <property name="enabled">
       <bool>false</bool>
      </property>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -16,16 +16,19 @@
      <property name="text">
       <string>Patient Browser</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_2">
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="inputsFormLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="dataDirectoryLabel">
         <property name="text">
          <string>Data directory</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="patientPrefixLabel">
         <property name="text">
          <string>Patient prefix</string>
         </property>
@@ -38,30 +41,9 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="PatientPrefix"/>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="outputsCollapsibleButton">
-     <property name="text">
-      <string>Outputs</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_4">
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton">
-     <property name="text">
-      <string>Advanced</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
      </layout>
     </widget>
    </item>
@@ -71,11 +53,23 @@
       <bool>false</bool>
      </property>
      <property name="toolTip">
-      <string>Run the algorithm.</string>
+      <string>Show files</string>
      </property>
      <property name="text">
-      <string>Apply</string>
+      <string>Show</string>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="outputsCollapsibleButton">
+     <property name="text">
+      <string>Outputs</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="outputsFormLayout">
+     </layout>
     </widget>
    </item>
    <item>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -14,62 +14,32 @@
    <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
-      <string>Inputs</string>
+      <string>Patient Browser</string>
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Input volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputSelector">
-        <property name="toolTip">
-         <string>Pick the input to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>false</bool>
+         <string>Data directory</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Image threshold:</string>
+         <string>Patient prefix</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkPathLineEdit" name="DataDirectory">
+        <property name="filters">
+         <set>ctkPathLineEdit::Dirs</set>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="ctkSliderWidget" name="imageThresholdSliderWidget">
-        <property name="toolTip">
-         <string>Set threshold value for computing the output image. Voxels that have intensities lower than this value will set to zero.</string>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="minimum">
-         <double>-100.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>500.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.500000000000000</double>
-        </property>
-       </widget>
+       <widget class="QLineEdit" name="PatientPrefix"/>
       </item>
      </layout>
     </widget>
@@ -80,68 +50,6 @@
       <string>Outputs</string>
      </property>
      <layout class="QFormLayout" name="formLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Thresholded volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputSelector">
-        <property name="toolTip">
-         <string>Pick the output to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Inverted volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="invertedOutputSelector">
-        <property name="toolTip">
-         <string>Result with inverted threshold will be written into this volume</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
@@ -154,23 +62,6 @@
       <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Invert threshold: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="invertOutputCheckBox">
-        <property name="toolTip">
-         <string>If checked, values above threshold are set to 0. If unchecked, values below are set to 0.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -12,6 +12,32 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QPushButton" name="HomeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Home</string>
+     </property>
+     <property name="text">
+      <string>Home</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="VPAWModelButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>VPAW Model</string>
+     </property>
+     <property name="text">
+      <string>VPAW Model</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
       <string>Patient Browser</string>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -68,8 +68,8 @@
      <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QFormLayout" name="outputsFormLayout">
-      <item>
+     <layout class="QGridLayout" name="outputsGridLayout">
+      <item row="0" column="0">
        <widget class="qMRMLSubjectHierarchyTreeView" name="subjectHierarchyTree">
         <property name="multiSelection">
          <bool>true</bool>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -69,6 +69,13 @@
       <bool>false</bool>
      </property>
      <layout class="QFormLayout" name="outputsFormLayout">
+      <item>
+       <widget class="qMRMLSubjectHierarchyTreeView" name="subjectHierarchyTree">
+        <property name="multiSelection">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -88,6 +95,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLSubjectHierarchyTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qMRMLSubjectHierarchyTreeView.h</header>
+  </customwidget>
   <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -351,15 +351,19 @@ class VPAWVisualizeWidget(
         with open(filename, "rb") as f:
             contents = pk.load(f)
 
-        print(f"File type for {filename} is not currently supported")  # !!!
-        print(f"{filename} contains {summary_repr(contents)}")
+        print(f"File type for {filename} is not currently supported")
+        print(f"{filename} contains {summary_repr(contents)}") # !!!
         # !!! Create node from contents
 
         return None
 
     def createNode(self, filename, basename_repr, props):
+        # Determine the node type from the filename extension, using its
+        # immediate-ancestor directory's name if necessary.  Note: check for
+        # ".seg.nrrd" before checking for ".nrrd".
         if filename.endswith(".seg.nrrd"):
             node = slicer.util.loadSegmentation(filename, properties=props)
+            node.CreateClosedSurfaceRepresentation()
         elif filename.endswith(".nrrd"):
             directory = os.path.basename(os.path.dirname(filename))
             if directory == "images":
@@ -367,6 +371,7 @@ class VPAWVisualizeWidget(
                 self.show_nodes.append(node)
             elif directory == "segmentations_computed":
                 node = slicer.util.loadSegmentation(filename, properties=props)
+                node.CreateClosedSurfaceRepresentation()
             else:
                 # Guess
                 node = slicer.util.loadVolume(filename, properties=props)
@@ -394,9 +399,6 @@ class VPAWVisualizeWidget(
         # MarkupsFile, ModelFile, ScalarOverlayFile, SegmentationFile,
         # ShaderPropertyFile, TableFile, TextFile, TransformFile, and VolumeFile.
 
-        # Determine the node type from the filename extension, using its
-        # immediate-ancestor directory's name if necessary.  Note: check for
-        # ".seg.nrrd" before checking for ".nrrd".
         basename = os.path.basename(filename)
         basename_repr = repr(basename)
         props = {"name": basename, "singleFile": True, "show": False}
@@ -458,7 +460,11 @@ class VPAWVisualizeWidget(
         if self.show_nodes:
             slicer.util.setSliceViewerLayers(foreground=self.show_nodes[0], fit=True)
         self.show_nodes = list()
-
+        # Center the 3D view
+        layoutManager = slicer.app.layoutManager()
+        threeDWidget = layoutManager.threeDWidget(0)
+        threeDView = threeDWidget.threeDView()
+        threeDView.resetFocalPoint()
 
 #
 # VPAWVisualizeLogic


### PR DESCRIPTION
Support Data Directory and Patient Prefix

ENH: Specify widgets in `VPAWVisualize.ui`
ENH: Support in `VPAWVisualizeWidget`, `VPAWVisualizeLogic`
ENH: Add `VPAWVisualizeLogic.find_files_with_prefix`
ENH: Create output widget for each discovered image
ENH: Gray out button when inputs are invalid
COMP: Make `flake8` happier
STYLE: Don't skip row numbers in widget layouts
STYLE: Use descriptive widget names

Deferred to a later pull request:
Make the `VPAWVisualize` module easier to get to from the `Home` module