### PR TITLE
Implement VPAWModel, to run segmentation/geometry pipeline on new cases

### DIFF
--- a/Modules/Scripted/Home/Home.py
+++ b/Modules/Scripted/Home/Home.py
@@ -8,7 +8,8 @@ import slicer.util
 
 
 class Home(slicer.ScriptedLoadableModule.ScriptedLoadableModule):
-    """Uses ScriptedLoadableModule base class, available at:
+    """
+    Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -31,7 +32,8 @@ class HomeWidget(
     slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget,
     slicer.util.VTKObservationMixin,
 ):
-    """Uses ScriptedLoadableModuleWidget base class, available at:
+    """
+    Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -168,12 +170,11 @@ class HomeWidget(
 
 
 class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
-    """This class should implement all the actual
-    computation done by your module.  The interface
-    should be such that other python code can import
-    this class and make use of the functionality without
-    requiring an instance of the Widget.
-    Uses ScriptedLoadableModuleLogic base class, available at:
+    """
+    This class should implement all the actual computation done by your module.  The
+    interface should be such that other python code can import this class and make use
+    of the functionality without requiring an instance of the Widget.  Uses
+    ScriptedLoadableModuleLogic base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -185,9 +186,9 @@ class HomeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
         pass
 
     def exitApplication(self, status=slicer.util.EXIT_SUCCESS, message=None):
-        """Exit application.
-        If ``status`` is ``slicer.util.EXIT_SUCCESS``, ``message`` is logged using
-        ``logging.info(message)`` otherwise it is logged using
+        """
+        Exit application.  If ``status`` is ``slicer.util.EXIT_SUCCESS``, ``message`` is
+        logged using ``logging.info(message)`` otherwise it is logged using
         ``logging.error(message)``.
         """
 
@@ -254,8 +255,10 @@ class HomeTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be
-        enough."""
+        """
+        Do whatever is needed to reset the state - typically a scene clear will be
+        enough.
+        """
         slicer.mrmlScene.Clear(0)
 
     def runTest(self):
@@ -264,15 +267,16 @@ class HomeTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest):
         self.test_Home1()
 
     def test_Home1(self):
-        """Ideally you should have several levels of tests.  At the lowest level
-        tests should exercise the functionality of the logic with different inputs
-        (both valid and invalid).  At higher levels your tests should emulate the
-        way the user would interact with your code and confirm that it still works
-        the way you intended.
+        """
+        Ideally you should have several levels of tests.  At the lowest level tests
+        should exercise the functionality of the logic with different inputs (both valid
+        and invalid).  At higher levels your tests should emulate the way the user would
+        interact with your code and confirm that it still works the way you intended.
+
         One of the most important features of the tests is that it should alert other
         developers when their changes will have an impact on the behavior of your
-        module.  For example, if a developer removes a feature that you depend on,
-        your test should break so they know that the feature is needed.
+        module.  For example, if a developer removes a feature that you depend on, your
+        test should break so they know that the feature is needed.
         """
 
         self.delayDisplay("Starting the test")

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -77,179 +77,73 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="runPediatricAirwayAtlasCollapsibleButton">
      <property name="text">
-      <string>VPAW Model: Inputs</string>
+      <string>VPAW Model: Run Pediatric Airway Atlas</string>
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="VPAWRootDirectoryLabel">
         <property name="text">
-         <string>Input volume:</string>
+         <string>Input/Output Root Directory</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="inputSelector">
-        <property name="toolTip">
-         <string>Pick the input to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Image threshold:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkSliderWidget" name="imageThresholdSliderWidget">
-        <property name="toolTip">
-         <string>Set threshold value for computing the output image. Voxels that have intensities lower than this value will set to zero.</string>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="minimum">
-         <double>-100.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>500.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.500000000000000</double>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="outputsCollapsibleButton">
-     <property name="text">
-      <string>Outputs</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Thresholded volume:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLNodeComboBox" name="outputSelector">
-        <property name="toolTip">
-         <string>Pick the output to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
+       <widget class="ctkPathLineEdit" name="VPAWRootDirectory">
+        <property name="filters">
+         <set>ctkPathLineEdit::Dirs</set>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="PAAConfigFileLabel">
         <property name="text">
-         <string>Inverted volume:</string>
+         <string>Configuration file (*.yaml)</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="qMRMLNodeComboBox" name="invertedOutputSelector">
-        <property name="toolTip">
-         <string>Result with inverted threshold will be written into this volume</string>
+       <widget class="ctkPathLineEdit" name="PAAConfigFile">
+        <property name="filters">
+         <set>ctkPathLineEdit::Files</set>
         </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
+        <property name="nameFilters">
+         <string>*.yaml</string>
         </property>
-        <property name="showChildNodeTypes">
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="PAASegmentationConfigFileLabel">
+        <property name="text">
+         <string>Segmentation Configuration file (*.yaml)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkPathLineEdit" name="PAASegmentationConfigFile">
+        <property name="filters">
+         <set>ctkPathLineEdit::Files</set>
+        </property>
+        <property name="nameFilters">
+         <string>*.yaml</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QPushButton" name="runPediatricAirwayAtlasButton">
+        <property name="enabled">
          <bool>false</bool>
         </property>
-        <property name="noneEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>true</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="ctkCollapsibleButton" name="advancedCollapsibleButton">
-     <property name="text">
-      <string>Advanced</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Invert threshold: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="invertOutputCheckBox">
         <property name="toolTip">
-         <string>If checked, values above threshold are set to 0. If unchecked, values below are set to 0.</string>
+         <string>Run Pediatric Airway Atlas</string>
         </property>
         <property name="text">
-         <string/>
+         <string>Run Pediatric Airway Atlas</string>
         </property>
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="applyButton">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="toolTip">
-      <string>Run the algorithm.</string>
-     </property>
-     <property name="text">
-      <string>Apply</string>
-     </property>
     </widget>
    </item>
    <item>
@@ -292,54 +186,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>VPAWModel</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>inputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>122</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>248</x>
-     <y>61</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VPAWModel</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>outputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>82</x>
-     <y>135</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>220</x>
-     <y>161</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>VPAWModel</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>invertedOutputSelector</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>161</x>
-     <y>8</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>173</x>
-     <y>176</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -40,7 +40,7 @@
    <item>
     <widget class="ctkCollapsibleButton" name="installPediatricAirwayAtlasCollapsibleButton" native="true">
      <property name="text" stdset="0">
-      <string>VPAW Model: Install Pediatric Airway Atlas</string>
+      <string>VPAW Model: Link to Pediatric Airway Atlas Codebase</string>
      </property>
      <property name="collapsed" stdset="0">
       <bool>false</bool>
@@ -66,10 +66,10 @@
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>Install Pediatric Airway Atlas and Dependencies</string>
+         <string>Link to Pediatric Airway Atlas codebase and install dependencies</string>
         </property>
         <property name="text">
-         <string>Install Pediatric Airway Atlas and Dependencies</string>
+         <string>Link to Pediatric Airway Atlas codebase and install dependencies</string>
         </property>
        </widget>
       </item>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -97,40 +97,20 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="PAAConfigFileLabel">
+       <widget class="QLabel" name="VPAWModelsDirectoryLabel">
         <property name="text">
-         <string>Configuration file (*.yaml)</string>
+         <string>Models Directory</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="ctkPathLineEdit" name="PAAConfigFile">
+       <widget class="ctkPathLineEdit" name="VPAWModelsDirectory">
         <property name="filters">
-         <set>ctkPathLineEdit::Files</set>
-        </property>
-        <property name="nameFilters">
-         <string>*.yaml</string>
+         <set>ctkPathLineEdit::Dirs</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="PAASegmentationConfigFileLabel">
-        <property name="text">
-         <string>Segmentation Configuration file (*.yaml)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkPathLineEdit" name="PAASegmentationConfigFile">
-        <property name="filters">
-         <set>ctkPathLineEdit::Files</set>
-        </property>
-        <property name="nameFilters">
-         <string>*.yaml</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
+      <item row="2" column="0" colspan="2">
        <widget class="QPushButton" name="runPediatricAirwayAtlasButton">
         <property name="enabled">
          <bool>false</bool>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -38,6 +38,45 @@
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="installPediatricAirwayAtlasCollapsibleButton" native="true">
+     <property name="text" stdset="0">
+      <string>VPAW Model: Install Pediatric Airway Atlas</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>false</bool>
+     </property>
+     <layout class="QFormLayout" name="installPediatricAirwayAtlasFormLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="pediatricAirwayAtlasDirectoryLabel">
+        <property name="text">
+         <string>Pediatric Airway Atlas source directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ctkPathLineEdit" name="PediatricAirwayAtlasDirectory">
+        <property name="filters">
+         <set>ctkPathLineEdit::Dirs</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="installPediatricAirwayAtlasButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Install Pediatric Airway Atlas and Dependencies</string>
+        </property>
+        <property name="text">
+         <string>Install Pediatric Airway Atlas and Dependencies</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
       <string>VPAW Model: Inputs</string>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -38,14 +38,14 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="installPediatricAirwayAtlasCollapsibleButton" native="true">
+    <widget class="ctkCollapsibleButton" name="linkPediatricAirwayAtlasCollapsibleButton" native="true">
      <property name="text" stdset="0">
       <string>VPAW Model: Link to Pediatric Airway Atlas Codebase</string>
      </property>
      <property name="collapsed" stdset="0">
       <bool>false</bool>
      </property>
-     <layout class="QFormLayout" name="installPediatricAirwayAtlasFormLayout">
+     <layout class="QFormLayout" name="linkPediatricAirwayAtlasFormLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="pediatricAirwayAtlasDirectoryLabel">
         <property name="text">
@@ -61,7 +61,7 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
-       <widget class="QPushButton" name="installPediatricAirwayAtlasButton">
+       <widget class="QPushButton" name="linkPediatricAirwayAtlasButton">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -110,7 +110,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0">
+       <widget class="QLabel" name="patientPrefixLabel">
+        <property name="text">
+         <string>Patient prefix (optional)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="PatientPrefix"/>
+      </item>
+      <item row="3" column="0" colspan="2">
        <widget class="QPushButton" name="runPediatricAirwayAtlasButton">
         <property name="enabled">
          <bool>false</bool>

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -15,7 +15,7 @@ import yaml
 
 class BusyCursor:
     """
-    Context manager for showing a busy cursor. Ensures that cursor reverts to normal in
+    Context manager for showing a busy cursor.  Ensures that cursor reverts to normal in
     case of an exception.
     """
 
@@ -33,7 +33,8 @@ class BusyCursor:
 
 
 class VPAWModel(slicer.ScriptedLoadableModule.ScriptedLoadableModule):
-    """Uses ScriptedLoadableModule base class, available at:
+    """
+    Uses ScriptedLoadableModule base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -41,9 +42,8 @@ class VPAWModel(slicer.ScriptedLoadableModule.ScriptedLoadableModule):
         slicer.ScriptedLoadableModule.ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "VPAW Model"
         self.parent.categories = ["VPAW"]
-        self.parent.dependencies = (
-            []
-        )  # TODO: add here list of module names that this module requires
+        # TODO: add here list of module names that this module requires
+        self.parent.dependencies = []
         self.parent.contributors = [
             "Andinet Enquobahrie (Kitware, Inc.)",
             "Shreeraj Jadhav (Kitware, Inc.)",
@@ -92,7 +92,8 @@ class VPAWModelWidget(
     slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget,
     slicer.util.VTKObservationMixin,
 ):
-    """Uses ScriptedLoadableModuleWidget base class, available at:
+    """
+    Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -123,9 +124,9 @@ class VPAWModelWidget(
         self.layout.addWidget(uiWidget)
         self.ui = slicer.util.childWidgetVariables(uiWidget)
 
-        # Set scene in MRML widgets. Make sure that in Qt designer the top-level
+        # Set scene in MRML widgets.  Make sure that in Qt designer the top-level
         # qMRMLWidget's "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each
-        # MRML widget's.  "setMRMLScene(vtkMRMLScene*)" slot.
+        # MRML widget's "setMRMLScene(vtkMRMLScene*)" slot.
         uiWidget.setMRMLScene(slicer.mrmlScene)
 
         # Configure 3D view
@@ -138,7 +139,7 @@ class VPAWModelWidget(
             slicer.vtkMRMLAbstractViewNode.OrientationMarkerTypeAxes
         )
 
-        # Create logic class. Logic implements all computations that should be possible
+        # Create logic class.  Logic implements all computations that should be possible
         # to run in batch mode, without a graphical user interface.
         self.logic = VPAWModelLogic()
 
@@ -235,7 +236,7 @@ class VPAWModelWidget(
         Ensure parameter node exists and observed.
         """
         # Parameter node stores all user choices in parameter values, node selections,
-        # etc.  so that when the scene is saved and reloaded, these settings are
+        # etc. so that when the scene is saved and reloaded, these settings are
         # restored.
 
         self.setParameterNode(self.logic.getParameterNode())
@@ -347,9 +348,8 @@ class VPAWModelWidget(
         if self._parameterNode is None or self._updatingGUIFromParameterNode:
             return
 
-        wasModified = (
-            self._parameterNode.StartModify()
-        )  # Modify all properties in a single batch
+        # Modify all properties in a single batch
+        wasModified = self._parameterNode.StartModify()
 
         self._parameterNode.SetParameter(
             "PediatricAirwayAtlasDirectory",
@@ -430,8 +430,8 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
 
     def __init__(self):
         """
-        Called when the logic class is instantiated. Can be used for initializing member
-        variables.
+        Called when the logic class is instantiated.  Can be used for initializing
+        member variables.
         """
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic.__init__(self)
 
@@ -633,7 +633,7 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                 )
             except:
                 slicer.util.errorDisplay(
-                    "The run failed. It may be that a non-blank patient prefix is not"
+                    "The run failed.  It may be that a non-blank patient prefix is not"
                     + " supported by this version of pediatric_airway_atlas"
                     + ".conversion_utils.generate_pixel_space_landmarks"
                     + ".convert_landmarks."
@@ -743,7 +743,7 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                     )
                 except:
                     slicer.util.errorDisplay(
-                        "The run failed. It may be that a non-blank patient prefix is"
+                        "The run failed.  It may be that a non-blank patient prefix is"
                         + " not supported by this version of pediatric_airway_atlas"
                         + ".atlas_builder_configurable."
                         + " Please update pediatric_airway_atlas and try again.",
@@ -786,8 +786,10 @@ class VPAWModelTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest):
     """
 
     def setUp(self):
-        """Do whatever is needed to reset the state - typically a scene clear will be
-        enough."""
+        """
+        Do whatever is needed to reset the state - typically a scene clear will be
+        enough.
+        """
         slicer.mrmlScene.Clear()
 
     def runTest(self):

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -297,8 +297,8 @@ class VPAWModelWidget(
         restarted).
         """
 
-        # If we got called to update QSettings because we updated the GUI from
-        # QSettings, then there's nothing more to do.  (Infinite loops are a drag.)
+        # If we got called to update QSettings because we updated the GUI from QSettings
+        # then there's nothing more to do.  (Infinite loops are a drag.)
         if self._updatingGUIFromQSettings:
             return
 
@@ -568,7 +568,7 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
             Process only files with this prefix.  Blank means all files.
         """
 
-        # If self.pediatric_airway_atlas is not yet set, then see if we can set it.
+        # If self.pediatric_airway_atlas is not yet set then see if we can set it.
         if not hasattr(self, "pediatric_airway_atlas_directory") and not (
             os.path.isdir(pediatricAirwayAtlasDirectory)
             and self.linkPediatricAirwayAtlas(pediatricAirwayAtlasDirectory)
@@ -624,7 +624,9 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                         "The run failed.  It may be that a non-blank patient prefix is"
                         + " not supported by this version of pediatric_airway_atlas"
                         + ".conversion_utils.generate_pixel_space_landmarks."
-                        + "  Please update pediatric_airway_atlas and try again.",
+                        + "  Please update pediatric_airway_atlas and try again."
+                        + "  Alternatively, it may be that you entered a patient prefix"
+                        + " that does not exist.",
                         "Run Error",
                     )
                     return False
@@ -745,7 +747,9 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                         "The run failed.  It may be that a non-blank patient prefix is"
                         + " not supported by this version of pediatric_airway_atlas"
                         + ".atlas_builder_configurable."
-                        + " Please update pediatric_airway_atlas and try again.",
+                        + "  Please update pediatric_airway_atlas and try again."
+                        + "  Alternatively, it may be that you entered a patient prefix"
+                        + " that does not exist.",
                         "Run Error",
                     )
                     return False

--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 import time
 import vtk
-import yaml
 
 
 class BusyCursor:
@@ -652,6 +651,9 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
         ConfigDescriptor, ConfigName = None, None
         SegmentDescriptor, SegmentName = None, None
         try:
+            # Cannot import yaml at file scope because it might not yet be installed at
+            # that time.
+            import yaml
             # Change directory and create files
             os.chdir(self.pediatric_airway_atlas_directory)
             ConfigDescriptor, ConfigName = tempfile.mkstemp(suffix=".yaml", text=True)

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -71,9 +71,8 @@ class VPAWVisualize(slicer.ScriptedLoadableModule.ScriptedLoadableModule):
         slicer.ScriptedLoadableModule.ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "VPAW Visualize"
         self.parent.categories = ["VPAW"]
-        self.parent.dependencies = (
-            []
-        )  # TODO: add here list of module names that this module requires
+        # TODO: add here list of module names that this module requires
+        self.parent.dependencies = []
         self.parent.contributors = [
             "Andinet Enquobahrie (Kitware, Inc.)",
             "Shreeraj Jadhav (Kitware, Inc.)",
@@ -148,15 +147,15 @@ class VPAWVisualizeWidget(
         """
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget.setup(self)
 
-        # Load widget from .ui file (created by Qt Designer).
-        # Additional widgets can be instantiated manually and added to self.layout.
+        # Load widget from .ui file (created by Qt Designer).  Additional widgets can be
+        # instantiated manually and added to self.layout.
         uiWidget = slicer.util.loadUI(self.resourcePath("UI/VPAWVisualize.ui"))
         self.layout.addWidget(uiWidget)
         self.ui = slicer.util.childWidgetVariables(uiWidget)
 
-        # Set scene in MRML widgets. Make sure that in Qt designer the top-level
+        # Set scene in MRML widgets.  Make sure that in Qt designer the top-level
         # qMRMLWidget's "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each
-        # MRML widget's.  "setMRMLScene(vtkMRMLScene*)" slot.
+        # MRML widget's "setMRMLScene(vtkMRMLScene*)" slot.
         uiWidget.setMRMLScene(slicer.mrmlScene)
 
         # Configure 3D view
@@ -169,7 +168,7 @@ class VPAWVisualizeWidget(
             slicer.vtkMRMLAbstractViewNode.OrientationMarkerTypeAxes
         )
 
-        # Create logic class. Logic implements all computations that should be possible
+        # Create logic class.  Logic implements all computations that should be possible
         # to run in batch mode, without a graphical user interface.
         self.logic = VPAWVisualizeLogic()
 
@@ -269,7 +268,7 @@ class VPAWVisualizeWidget(
         Ensure parameter node exists and observed.
         """
         # Parameter node stores all user choices in parameter values, node selections,
-        # etc.  so that when the scene is saved and reloaded, these settings are
+        # etc. so that when the scene is saved and reloaded, these settings are
         # restored.
 
         self.setParameterNode(self.logic.getParameterNode())
@@ -360,9 +359,8 @@ class VPAWVisualizeWidget(
         if self._parameterNode is None or self._updatingGUIFromParameterNode:
             return
 
-        wasModified = (
-            self._parameterNode.StartModify()
-        )  # Modify all properties in a single batch
+        # Modify all properties in a single batch
+        wasModified = self._parameterNode.StartModify()
 
         self._parameterNode.SetParameter(
             "DataDirectory", self.ui.DataDirectory.currentPath
@@ -424,24 +422,23 @@ class VPAWVisualizeWidget(
             waitCursor=True,
         ):
             try:
-                self.ui.computeIsosurfacesStackedWidget.setCurrentIndex(
-                    1
-                )  # show progress bar
+                # show progress bar
+                self.ui.computeIsosurfacesStackedWidget.setCurrentIndex(1)
 
                 def progress_callback(progress_percentage):
                     self.ui.computeIsosurfacesProgressBar.setValue(progress_percentage)
 
                 progress_callback(0)
-                # I found the following processEvents call was needed to get the widget to visually
-                # repaint before the progress increases in the computation. -E
+                # I found the following processEvents call was needed to get the widget
+                # to visually repaint before the progress increases in the
+                # computation.  -E
                 slicer.app.processEvents()
                 self.logic.compute_isosurfaces(
                     self.ui.numberOfIsosurfaceValues.value, progress_callback
                 )
             finally:
-                self.ui.computeIsosurfacesStackedWidget.setCurrentIndex(
-                    0
-                )  # revert to showing button
+                # revert to showing button
+                self.ui.computeIsosurfacesStackedWidget.setCurrentIndex(0)
                 self.updateComputeIsosurfacesButtonEnabledness()
 
     def onSegmentationOpacitySliderValueChanged(self, value: int):
@@ -486,8 +483,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
     def __init__(self):
         """
-        Called when the logic class is instantiated. Can be used for initializing member
-        variables.
+        Called when the logic class is instantiated.  Can be used for initializing
+        member variables.
         """
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic.__init__(self)
         self.clearSubject()
@@ -639,8 +636,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
         Parameters
         ----------
-        contents : a pair of arrays (centerline_points, centerline_normals). Currently we only use
-            centerline_points, piecing them together into a curve node.
+        contents : a pair of arrays (centerline_points, centerline_normals).  Currently
+            we only use centerline_points, piecing them together into a curve node.
 
         Returns
         -------
@@ -658,10 +655,10 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         )
         centerline_node.GetDisplayNode().SetGlyphTypeFromString("Vertex2D")
         centerline_node.SetCurveTypeToLinear()
-        centerline_node.LockedOn()  # don't allow mouse interaction to move control points
-        centerline_node.GetDisplayNode().SetPropertiesLabelVisibility(
-            False
-        )  # hide the text label because it distracts from landmarks
+        # don't allow mouse interaction to move control points
+        centerline_node.LockedOn()
+        # hide the text label because it distracts from landmarks
+        centerline_node.GetDisplayNode().SetPropertiesLabelVisibility(False)
         return centerline_node
 
     def loadOneNode(self, filename, basename_repr, props):
@@ -723,9 +720,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         the subject hierarchy.
         """
         self.subject_id = None
-        self.subject_item_id = (
-            None  # subject hierarchy item id for the currently loaded subject
-        )
+        # subject hierarchy item id for the currently loaded subject
+        self.subject_item_id = None
         self.input_image_node = None
         self.input_ijk_to_ras = None
         self.centerline_node = None
@@ -878,7 +874,7 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
     def fix_image_origins_and_spacings(self):
         """
         Some nodes rely on others for origin and spacing info, because it wasn't
-        properly saved in the files from which we generate those nodes. This functions
+        properly saved in the files from which we generate those nodes.  This functions
         goes through and transfers origin and spacing info whereever it is needed.
         """
         if self.laplace_sol_node is None:
@@ -898,7 +894,7 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
     def restrict_laplace_sol_to_segmentation(self):
         """
         If the laplace solution and the segmentation node both exist, mask the laplace
-        solution volume by the segmentation node. If either of them doesn't exists,
+        solution volume by the segmentation node.  If either of them doesn't exists,
         raise an exception.
         """
         if self.segmentation_node is None:
@@ -971,8 +967,9 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
             raise RuntimeError("Could not find a loaded Laplace solution image")
         if self.laplace_sol_masked_node is None:
             raise RuntimeError(
-                "No masked Laplace solution was found; there should be a volume node consisting of"
-                " the Laplace solution restricted to the airway segmentation."
+                "No masked Laplace solution was found; there should be a volume node"
+                " consisting of the Laplace solution restricted to the airway"
+                " segmentation."
             )
 
         isosurface_values = np.linspace(0, 1, num_isosurface_values)

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -191,6 +191,12 @@ class VPAWVisualizeWidget(
         self.ui.PatientPrefix.connect(
             "textChanged(const QString&)", self.updateParameterNodeFromGUI
         )
+        self.ui.DataDirectory.connect(
+            "validInputChanged(bool)", self.updateParameterNodeFromGUI
+        )
+        self.ui.PatientPrefix.connect(
+            "validInputChanged(bool)", self.updateParameterNodeFromGUI
+        )
 
         # Buttons
         self.ui.HomeButton.connect("clicked(bool)", self.onHomeButton)

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -280,7 +280,11 @@ class VPAWVisualizeWidget(
         # selected.  Changes of parameter node are observed so that whenever parameters
         # are changed by a script or any other module those are reflected immediately in
         # the GUI.
-        if self._parameterNode is not None:
+        if self._parameterNode is not None and self.hasObserver(
+            self._parameterNode,
+            vtk.vtkCommand.ModifiedEvent,
+            self.updateGUIFromParameterNode,
+        ):
             self.removeObserver(
                 self._parameterNode,
                 vtk.vtkCommand.ModifiedEvent,

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -45,7 +45,10 @@ def summary_repr(contents):
             + "}"
         )
     elif isinstance(contents, set):
-        return "{" + ", ".join([summary_repr(elem) for elem in contents]) + "}"
+        if len(contents) == 0:
+            return repr(set())
+        else:
+            return "{" + ", ".join([summary_repr(elem) for elem in contents]) + "}"
     elif isinstance(contents, (int, float, np.float32, np.float64, bool, str)):
         return repr(contents)
     elif isinstance(contents, np.ndarray):
@@ -893,7 +896,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
     def restrict_laplace_sol_to_segmentation(self):
         """If the laplace solution and the segmentation node both exist, mask the laplace solution
-        volume by the segmentation node. If either of them doesn't exists, raise an exception."""
+        volume by the segmentation node. If either of them doesn't exists, raise an exception.
+        """
 
         if self.segmentation_node is None:
             raise RuntimeError("Could not find segmentation node.")

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -193,9 +193,6 @@ class VPAWVisualizeWidget(
         self.ui.DataDirectory.connect(
             "validInputChanged(bool)", self.updateParameterNodeFromGUI
         )
-        self.ui.PatientPrefix.connect(
-            "validInputChanged(bool)", self.updateParameterNodeFromGUI
-        )
 
         # Buttons
         self.ui.HomeButton.connect("clicked(bool)", self.onHomeButton)
@@ -624,8 +621,7 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
             return self.loadCenterlineFromP3FileContents(contents)
 
         print(f"File type for {filename} is not currently supported")
-        print(f"{filename} contains {summary_repr(contents)}")  # !!!
-        # !!! Create node from contents
+        print(f"{filename} contains {summary_repr(contents)}")
 
         return None
 

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -25,7 +25,6 @@ def summary_repr(contents):
     -------
     A string representation of a summary of the object
     """
-
     if isinstance(contents, list):
         return "[" + ", ".join([summary_repr(elem) for elem in contents]) + "]"
     elif isinstance(contents, tuple):
@@ -94,7 +93,6 @@ This file was built from template originally developed by Jean-Christophe Fillio
 Kitware Inc., Andras Lasso, PerkLab, and Steve Pieper, Isomics, Inc. and was partially
 funded by NIH grant 3P41RR013218-12S1.
 """
-
         # Additional initialization step after application startup is complete
         slicer.app.connect("startupCompleted()", registerSampleData)
 
@@ -108,7 +106,6 @@ def registerSampleData():
     """
     Add data sets to Sample Data module.
     """
-
     # It is always recommended to provide sample data for users to make it easy to try
     # the module, but if no sample data is available then this method (and associated
     # startupCompeted signal connection) can be removed.
@@ -135,7 +132,6 @@ class VPAWVisualizeWidget(
         Called when the user opens the module the first time and the widget is
         initialized.
         """
-
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget.__init__(
             self, parent
         )
@@ -150,7 +146,6 @@ class VPAWVisualizeWidget(
         Called when the user opens the module the first time and the widget is
         initialized.
         """
-
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleWidget.setup(self)
 
         # Load widget from .ui file (created by Qt Designer).
@@ -205,6 +200,8 @@ class VPAWVisualizeWidget(
             "clicked(bool)", self.onComputeIsosurfacesButton
         )
         self.updateComputeIsosurfacesButtonEnabledness()
+
+        # Sliders
         self.ui.segmentationOpacitySlider.connect(
             "valueChanged(int)", self.onSegmentationOpacitySliderValueChanged
         )
@@ -224,14 +221,12 @@ class VPAWVisualizeWidget(
         """
         Called when the application closes and the module widget is destroyed.
         """
-
         self.removeObservers()
 
     def enter(self):
         """
         Called each time the user opens this module.
         """
-
         # Make sure parameter node exists and observed
         self.initializeParameterNode()
 
@@ -239,7 +234,6 @@ class VPAWVisualizeWidget(
         """
         Called each time the user opens a different module.
         """
-
         # Do not react to parameter node changes (GUI wlil be updated when the user
         # enters into the module)
         self.removeObserver(
@@ -252,7 +246,6 @@ class VPAWVisualizeWidget(
         """
         Called just before the scene is closed.
         """
-
         # Parameter node will be reset, do not use it anymore
         self.setParameterNode(None)
 
@@ -260,7 +253,6 @@ class VPAWVisualizeWidget(
         """
         Called just after the scene is closed.
         """
-
         # If this module is shown while the scene is closed then recreate a new
         # parameter node immediately
         if self.parent.isEntered:
@@ -270,7 +262,6 @@ class VPAWVisualizeWidget(
         """
         Ensure parameter node exists and observed.
         """
-
         # Parameter node stores all user choices in parameter values, node selections,
         # etc.  so that when the scene is saved and reloaded, these settings are
         # restored.
@@ -282,7 +273,6 @@ class VPAWVisualizeWidget(
         Set and observe parameter node.  Observation is needed because when the
         parameter node is changed then the GUI must be updated immediately.
         """
-
         if inputParameterNode:
             self.logic.setDefaultParameters(inputParameterNode)
 
@@ -309,10 +299,9 @@ class VPAWVisualizeWidget(
 
     def updateGUIFromParameterNode(self, caller=None, event=None):
         """
-        This method is called whenever parameter node is changed.
-        The module GUI is updated to show the current state of the parameter node.
+        This method is called whenever parameter node is changed.  The module GUI is
+        updated to show the current state of the parameter node.
         """
-
         if self._parameterNode is None or self._updatingGUIFromParameterNode:
             return
 
@@ -358,7 +347,6 @@ class VPAWVisualizeWidget(
         are saved into the parameter node (so that they are restored when the scene is
         saved and loaded).
         """
-
         if self._parameterNode is None or self._updatingGUIFromParameterNode:
             return
 
@@ -375,21 +363,21 @@ class VPAWVisualizeWidget(
 
     @vtk.calldata_type(vtk.VTK_LONG)
     def shItemModifiedEvent(self, caller, eventId, callData):
-        """Callback for when a subject hierarchy item is modified."""
+        """
+        Callback for when a subject hierarchy item is modified.
+        """
         qt.QTimer.singleShot(2000, self.updateComputeIsosurfacesButtonEnabledness)
 
     def onHomeButton(self):
         """
         Switch to the "Home" module when the user clicks the button.
         """
-
         slicer.util.selectModule("Home")
 
     def onVPAWModelButton(self):
         """
         Switch to the "VPAW Model" module when the user clicks the button.
         """
-
         slicer.util.selectModule("VPAWModel")
 
     def onShowButton(self):
@@ -397,7 +385,6 @@ class VPAWVisualizeWidget(
         When the user clicks the Show button, find the requested files and load them in
         to 3D Slicer's subject hierarchy.
         """
-
         with slicer.util.tryWithErrorDisplay(
             "Failed to show patient data.", waitCursor=True
         ):
@@ -422,7 +409,6 @@ class VPAWVisualizeWidget(
         """
         Compute isosurfaces of the laplace sol'n image
         """
-
         with slicer.util.tryWithErrorDisplay(
             "Unable to compute isosurfaces; see exception message below.",
             waitCursor=True,
@@ -454,7 +440,10 @@ class VPAWVisualizeWidget(
         )
 
     def updateComputeIsosurfacesButtonEnabledness(self):
-        """Enable or disable the compute isosurfaces button based on state of the VPAWVisualizeLogic"""
+        """
+        Enable or disable the compute isosurfaces button based on state of the
+        VPAWVisualizeLogic
+        """
         if not self.logic.subjectIsCurrentlyLoaded():
             self.ui.computeIsosurfacesButton.setEnabled(False)
             self.ui.computeIsosurfacesButton.setToolTip("Load a subject to enable this")
@@ -477,10 +466,11 @@ class VPAWVisualizeWidget(
 
 
 class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
-    """This class should implement all the actual computation done by your module.  The
+    """
+    This class should implement all the actual computation done by your module.  The
     interface should be such that other python code can import this class and make use
-    of the functionality without requiring an instance of the Widget.
-    Uses ScriptedLoadableModuleLogic base class, available at:
+    of the functionality without requiring an instance of the Widget.  Uses
+    ScriptedLoadableModuleLogic base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -489,7 +479,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         Called when the logic class is instantiated. Can be used for initializing member
         variables.
         """
-
         slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic.__init__(self)
         self.clearSubject()
 
@@ -497,7 +486,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         """
         Initialize parameter node with default settings.
         """
-
         if not parameterNode.GetParameter("Threshold"):
             parameterNode.SetParameter("Threshold", "100.0")
         if not parameterNode.GetParameter("Invert"):
@@ -529,7 +517,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         When `path` is a directory, returns the concatenation of the lists generated by
             a recursive call to find_files_with_prefix for each entry in the directory.
         """
-
         if os.path.isdir(path):
             # This `path` is a directory.  Recurse to all files and directories within
             # `path` and flatten the responses into a single list.
@@ -577,7 +564,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         When `path` is a directory, returns a list of the requested files, sorted
         chronologically by their modification times in
         """
-
         if not (isinstance(dataDirectory, str) and os.path.isdir(dataDirectory)):
             raise ValueError(
                 f"Data directory (value={repr(dataDirectory)}) is not valid"
@@ -624,7 +610,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         -------
         A 3D Slicer node object representing the data
         """
-
         with open(filename, "rb") as f:
             contents = pk.load(f)
 
@@ -639,7 +624,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
     def loadCenterlineFromP3FileContents(self, contents):
         """
-        Load a centerline using the data object written into a P3 file named "####_CENTERLINE.p3"
+        Load a centerline using the data object written into a P3 file named
+        "####_CENTERLINE.p3"
 
         Parameters
         ----------
@@ -686,7 +672,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         -------
         A 3D Slicer node object representing the data
         """
-
         # Determine the node type from the filename extension, using its
         # immediate-ancestor directory's name if necessary.  Note: check for ".seg.nrrd"
         # before checking for ".nrrd".
@@ -723,8 +708,10 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         return node
 
     def clearSubject(self):
-        """Set VPAWVisualizeLogic to initial state before any subject was loaded,
-        and clear the subject hierarchy."""
+        """
+        Set VPAWVisualizeLogic to initial state before any subject was loaded, and clear
+        the subject hierarchy.
+        """
         self.subject_id = None
         self.subject_item_id = (
             None  # subject hierarchy item id for the currently loaded subject
@@ -742,17 +729,20 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         """
         Remove all nodes from the 3D Slicer subject hierarchy
         """
-
         slicer.mrmlScene.GetSubjectHierarchyNode().RemoveAllItems(True)
         self.show_nodes = list()
 
     def subjectIsCurrentlyLoaded(self) -> bool:
-        """Whether a subject has been loaded."""
+        """
+        Whether a subject has been loaded.
+        """
         return self.subject_id is not None
 
     def put_node_under_subject(self, node):
-        """Move the given node in the subject hierarchy such that it becomes a child of the
-        subject item for the currently loaded subject."""
+        """
+        Move the given node in the subject hierarchy such that it becomes a child of the
+        subject item for the currently loaded subject.
+        """
         shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
         node_item = shNode.GetItemByDataNode(node)
         shNode.SetItemParent(node_item, self.subject_item_id)
@@ -771,7 +761,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         filename: str
             The data source for the file
         """
-
         # The node types supported by 3D Slicer generally can be found with fgrep
         # 'loadNodeFromFile(filename' from
         # https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/util.py.
@@ -811,7 +800,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         subject_name : str
             Name for folder in subject hierarchy to contain the nodes
         """
-
         self.subject_id = subject_name
 
         # The subject hierarchy node can contain subject (patient), study (optionally),
@@ -864,7 +852,9 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         slicer.mrmlScene.EndState(slicer.vtkMRMLScene.ImportState)
 
     def create_input_ijk2ras_as_node(self):
-        """Get the IJK to RAS matrix for the input image as a transform node."""
+        """
+        Get the IJK to RAS matrix for the input image as a transform node.
+        """
         if self.input_image_node is None:
             raise RuntimeError("Could not find input image node.")
         ijkToRas = vtk.vtkMatrix4x4()
@@ -876,10 +866,11 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         self.input_ijk_to_ras = ijkToRas_node
 
     def fix_image_origins_and_spacings(self):
-        """Some nodes rely on others for origin and spacing info, because it wasn't properly saved
-        in the files from which we generate those nodes. This functions goes through and transfers
-        origin and spacing info whereever it is needed."""
-
+        """
+        Some nodes rely on others for origin and spacing info, because it wasn't
+        properly saved in the files from which we generate those nodes. This functions
+        goes through and transfers origin and spacing info whereever it is needed.
+        """
         if self.laplace_sol_node is None:
             raise RuntimeError("Could not find laplace solution node.")
         if self.input_image_node is None:
@@ -895,10 +886,11 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         self.centerline_node.SetAndObserveTransformNodeID(self.input_ijk_to_ras.GetID())
 
     def restrict_laplace_sol_to_segmentation(self):
-        """If the laplace solution and the segmentation node both exist, mask the laplace solution
-        volume by the segmentation node. If either of them doesn't exists, raise an exception.
         """
-
+        If the laplace solution and the segmentation node both exist, mask the laplace
+        solution volume by the segmentation node. If either of them doesn't exists,
+        raise an exception.
+        """
         if self.segmentation_node is None:
             raise RuntimeError("Could not find segmentation node.")
         if self.laplace_sol_node is None:
@@ -931,7 +923,6 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         """
         Make the 3D Slicer viewing panels default to something reasonable
         """
-
         # Make sure at least one input image (if any) is being viewed
         if self.show_nodes:
             slicer.util.setSliceViewerLayers(foreground=self.show_nodes[0], fit=True)
@@ -947,19 +938,23 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         threeDView.lookFromAxis(ctk.ctkAxesWidget.Left)
 
     def set_segmentation_node_opacity(self, opacity):
-        """Set segmentation node opacity, a float in [0,1], if segmentation node exists.
-        If segmentation node doesn't exist, this simply does nothing."""
+        """
+        Set segmentation node opacity, a float in [0,1], if segmentation node exists.
+        If segmentation node doesn't exist, this simply does nothing.
+        """
         if self.segmentation_node is not None:
             self.segmentation_node.GetDisplayNode().SetOpacity3D(opacity)
 
     def compute_isosurfaces(self, num_isosurface_values: int, progress_callback=None):
-        """Compute isosurfaces of the laplace solution image, if one exists.
-        Raises exception if none exists.
+        """
+        Compute isosurfaces of the laplace solution image, if one exists.  Raises
+        exception if none exists.
 
         Args:
             num_isosurface_values: number of isosurface values
-            progress_callback: Optionally, a function that takes a progress_percentage float value.
-                If this is provided then progress_callback(progress_percentage) will be called by
+            progress_callback: Optionally, a function that takes a progress_percentage
+                float value.  If this is provided then
+                progress_callback(progress_percentage) will be called by
                 compute_isosurfaces while the computation is being done.
         """
         if self.laplace_sol_node is None:
@@ -972,7 +967,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
         isosurface_values = np.linspace(0, 1, num_isosurface_values)
 
-        # this does not work so well at actual min or max value so we leave a bit of room
+        # this does not work so well at actual min or max value so we leave a bit of
+        # room
         isosurface_values[0] += 0.02
         isosurface_values[-1] -= 0.02
 
@@ -990,7 +986,9 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
         self.laplace_isosurface_node = laplace_isosurface_node
 
     def isosurface_exists(self) -> bool:
-        """Whether isosurface has already been computed"""
+        """
+        Whether isosurface has already been computed
+        """
         return (
             self.laplace_isosurface_node is not None
             and slicer.mrmlScene.GetNodeByID(self.laplace_isosurface_node.GetID())
@@ -1005,8 +1003,8 @@ class VPAWVisualizeLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLog
 
 class VPAWVisualizeTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest):
     """
-    This is the test case for your scripted module.
-    Uses ScriptedLoadableModuleTest base class, available at:
+    This is the test case for your scripted module.  Uses ScriptedLoadableModuleTest
+    base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
@@ -1015,27 +1013,27 @@ class VPAWVisualizeTest(slicer.ScriptedLoadableModule.ScriptedLoadableModuleTest
         Do whatever is needed to reset the state - typically a scene clear will be
         enough.
         """
-
         slicer.mrmlScene.Clear()
 
     def runTest(self):
-        """Run as few or as many tests as needed here."""
+        """
+        Run as few or as many tests as needed here.
+        """
         self.setUp()
         self.test_VPAWVisualize1()
 
     def test_VPAWVisualize1(self):
         """
-        Ideally you should have several levels of tests.  At the lowest level tests
+        Ideally we should have several levels of tests.  At the lowest level tests
         should exercise the functionality of the logic with different inputs (both valid
-        and invalid).  At higher levels your tests should emulate the way the user would
-        interact with your code and confirm that it still works the way you intended.
+        and invalid).  At higher levels our tests should emulate the way the user would
+        interact with our code and confirm that it still works the way we intended.
 
         One of the most important features of the tests is that it should alert other
-        developers when their changes will have an impact on the behavior of your
-        module.  For example, if a developer removes a feature that you depend on, your
-        test should break so they know that the feature is needed.
+        developers when their changes will have an impact on the behavior of our module.
+        For example, if a developer removes a feature that we depend on, our test should
+        break so they know that the feature is needed.
         """
-
         self.delayDisplay("Starting the test")
 
         # Get/create input data

--- a/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
+++ b/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
@@ -5,17 +5,18 @@ import slicer
 def isosurfaces_from_volume(
     vol_node, thresholds, decimate_target_reduction=0.25, progress_callback=None
 ):
-    """Compute a model node consisting of isosurfaces from the given volume node.
-    Uses vtkFlyingEdges3D to generate isosurface mesh.
+    """
+    Compute a model node consisting of isosurfaces from the given volume node.  Uses
+    vtkFlyingEdges3D to generate isosurface mesh.
 
     Args:
         vol_node: a vtkMRMLScalarVolumeNode
-        thresholds: a sequence of floats; values at which to threshold the scalar volume. each value
-            should result in one isosurface
+        thresholds: a sequence of floats; values at which to threshold the scalar
+            volume.  Each value should result in one isosurface
         decimate_target_reduction: by how much to decimate after doing vtkFlyingEdges3D
-        progress_callback: Optionally, a function that takes a progress_percentage float value.
-            If this is provided then progress_callback(progress_percentage) will be called
-            while the computation is being done.
+        progress_callback: Optionally, a function that takes a progress_percentage float
+            value.  If this is provided then progress_callback(progress_percentage) will
+            be called while the computation is being done.
     Return: a vtkMRMLModelNode
     """
 

--- a/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
+++ b/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
@@ -20,6 +20,7 @@ def isosurfaces_from_volume(
     """
 
     if progress_callback is None:
+
         def progress_callback(progress_percentage):
             pass
 


### PR DESCRIPTION
Closes #11.  The VPAWModel button in the application is now connected to a user interface and implementation that supports:

1. Install `pediatric_airway_atlas` and all of its Python package dependencies.  Because the repository for it is not public, the user is able to access the top-level code after specifying its location on the local computer.  The Python package dependencies are installed into the environment maintained by the underlying 3D Slicer apparatus and to not affect global or virtual Python environments.
2. Run the full pipeline.  Inputs to be specified are (1) the input / output directory (called `vpaw-root-dir` in some of our examples), which contains `images/*`, `landmarks/*`, and `FilteredControlBlindingLogUniqueScanFiltered.xls`, and (2) the models directory (called `models` in some of our examples), which contains a file with a name like `116(158.10-38.AM.24.Mar).pth`.