### PR TITLE
ENH: Put VPAWModel button before VPAWVisualize button

### DIFF
--- a/Modules/Scripted/Home/Resources/UI/Home.ui
+++ b/Modules/Scripted/Home/Resources/UI/Home.ui
@@ -12,19 +12,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPushButton" name="VPAWVisualizeButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Go to VPAW Visualize module</string>
-     </property>
-     <property name="text">
-      <string>Go to VPAW Visualize module</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="VPAWModelButton">
      <property name="enabled">
       <bool>true</bool>
@@ -34,6 +21,19 @@
      </property>
      <property name="text">
       <string>Go to VPAW Model module</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="VPAWVisualizeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Go to VPAW Visualize module</string>
+     </property>
+     <property name="text">
+      <string>Go to VPAW Visualize module</string>
      </property>
     </widget>
    </item>

--- a/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
+++ b/Modules/Scripted/VPAWModel/Resources/UI/VPAWModel.ui
@@ -12,19 +12,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPushButton" name="VPAWVisualizeButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Go to VPAW Visualize module</string>
-     </property>
-     <property name="text">
-      <string>Go to VPAW Visualize module</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="HomeButton">
      <property name="enabled">
       <bool>true</bool>
@@ -34,6 +21,19 @@
      </property>
      <property name="text">
       <string>Go to Home module</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="VPAWVisualizeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Go to VPAW Visualize module</string>
+     </property>
+     <property name="text">
+      <string>Go to VPAW Visualize module</string>
      </property>
     </widget>
    </item>

--- a/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
+++ b/Modules/Scripted/VPAWVisualize/Resources/UI/VPAWVisualize.ui
@@ -12,19 +12,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QPushButton" name="HomeButton">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Go to Home module</string>
-     </property>
-     <property name="text">
-      <string>Go to Home module</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QPushButton" name="VPAWModelButton">
      <property name="enabled">
       <bool>true</bool>
@@ -34,6 +21,19 @@
      </property>
      <property name="text">
       <string>Go to VPAW Model module</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="HomeButton">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Go to Home module</string>
+     </property>
+     <property name="text">
+      <string>Go to Home module</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Because the typical workflow is to run the pipeline (using the VPAW Model module) and then view the outputs (using the VPAW Visualize module), put the button for the former before the button for the latter.