### PR TITLE
COMP: Remove SlicerIMSTK dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.16.3)
-cmake_policy(SET CMP0135 NEW)
+foreach(p
+    CMP0135 # CMake 3.24
+  )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 # Enable C++17
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.16.3)
+if(COMMAND CMAKE_POLICY)
+  cmake_policy(SET CMP0135 NEW)
+endif(COMMAND CMAKE_POLICY)
 
-# Enable C++14
+# Enable C++17
 if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -182,18 +185,18 @@ FetchContent_Populate(${extension_name}
  )
 list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
-#SlicerIMSTK
-set(extension_name "SlicerIMSTK")
-set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
-FetchContent_Populate(${extension_name}
- SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
- GIT_REPOSITORY https://github.com/KitwareMedical/SlicerIMSTK.git
- GIT_TAG        cd37cd73f853cf3cb09b9611d9cb715d5f84613c
- GIT_PROGRESS   1
- QUIET
- )
-message(STATUS "Remote - ${extension_name} [OK]")
-list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
+# #SlicerIMSTK
+# set(extension_name "SlicerIMSTK")
+# set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
+# FetchContent_Populate(${extension_name}
+#  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
+#  GIT_REPOSITORY https://github.com/KitwareMedical/SlicerIMSTK.git
+#  GIT_TAG        cd37cd73f853cf3cb09b9611d9cb715d5f84613c
+#  GIT_PROGRESS   1
+#  QUIET
+#  )
+# message(STATUS "Remote - ${extension_name} [OK]")
+# list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
 #SlicerSegmentEditorExtraEffects modules
 set(extension_name "SlicerSegmentEditorExtraEffects")
@@ -208,7 +211,7 @@ FetchContent_Populate(${extension_name}
 message(STATUS "Remote - ${extension_name} [OK]")
 list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
-include(${SlicerIMSTK_SOURCE_DIR}/SuperBuildPrerequisites.cmake)
+# include(${SlicerIMSTK_SOURCE_DIR}/SuperBuildPrerequisites.cmake)
 
 # Add Slicer sources
 add_subdirectory(${slicersources_SOURCE_DIR} ${slicersources_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
-if(COMMAND CMAKE_POLICY)
-  cmake_policy(SET CMP0135 NEW)
-endif(COMMAND CMAKE_POLICY)
+cmake_policy(SET CMP0135 NEW)
 
 # Enable C++17
 if(NOT DEFINED CMAKE_CXX_STANDARD)


### PR DESCRIPTION
IMSTK is currently unused by VPAW. On Microsoft Windows (11 Pro, 22H2), it has dependencies that want C++14 instead of C++17, which break the overall VPAW build.

Edit: the offending dependency is `assimp`.