### PR TITLE
ENH: Add modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ if(WIN32)
   option(Slicer_BUILD_WIN32_CONSOLE             "Build application executable as a console app (allows capturing and piping console output)" ON)
 endif()
 
-option(vpaw_USE_IMSTK                           "Enable IMSTK-related capabilities"                   OFF)
 option(Slicer_BUILD_DICOM_SUPPORT               "Build application with DICOM support"                ON)
 option(Slicer_BUILD_DIFFUSION_SUPPORT           "Build application with Diffusion support"            OFF)
 option(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT    "Build application with ExtensionManager support"     ON)
@@ -188,22 +187,6 @@ list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR}/ImageSt
 #  QUIET
 #  )
 # list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
-
-#SlicerIMSTK
-if(vpaw_USE_IMSTK)
-  set(extension_name "SlicerIMSTK")
-  set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
-  FetchContent_Populate(${extension_name}
-   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-   GIT_REPOSITORY https://github.com/KitwareMedical/SlicerIMSTK.git
-   GIT_TAG        cd37cd73f853cf3cb09b9611d9cb715d5f84613c
-   GIT_PROGRESS   1
-   QUIET
-   )
-  message(STATUS "Remote - ${extension_name} [OK]")
-  list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
-  include(${${extension_name}_SOURCE_DIR}/SuperBuildPrerequisites.cmake)
-endif()
 
 #SlicerSegmentEditorExtraEffects modules
 set(extension_name "SlicerSegmentEditorExtraEffects")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ set(Slicer_QTLOADABLEMODULES_DISABLED
 set(Slicer_QTSCRIPTEDMODULES_DISABLED
   DataProbe
   DMRIInstall
-  Endoscopy
   LabelStatistics
   PerformanceTests
   VectorToScalarVolume
@@ -213,6 +212,30 @@ FetchContent_Populate(${extension_name}
  QUIET
  )
 message(STATUS "Remote - ${extension_name} [OK]")
+list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
+
+#MarkupsToModel modules
+set(extension_name "MarkupsToModel")
+set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
+FetchContent_Populate(${extension_name}
+ SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
+ GIT_REPOSITORY https://github.com/SlicerIGT/SlicerMarkupsToModel.git
+ GIT_TAG        312cf9f8ccb84613e191a0a3f18cd3f865026aeb  #2023-08-23
+ GIT_PROGRESS   1
+ QUIET
+ )
+list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
+
+#AirwaySegmentation modules
+set(extension_name "AirwaySegmentation")
+set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
+FetchContent_Populate(${extension_name}
+ SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
+ GIT_REPOSITORY https://github.com/Slicer/SlicerAirwaySegmentation.git
+ GIT_TAG        d3954e4c1b943353811132d49111f58e40ded5b8  #2022-03-22
+ GIT_PROGRESS   1
+ QUIET
+ )
 list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
 # include(${SlicerIMSTK_SOURCE_DIR}/SuperBuildPrerequisites.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ if(WIN32)
   option(Slicer_BUILD_WIN32_CONSOLE             "Build application executable as a console app (allows capturing and piping console output)" ON)
 endif()
 
+option(vpaw_USE_IMSTK                           "Enable IMSTK-related capabilities"                   OFF)
 option(Slicer_BUILD_DICOM_SUPPORT               "Build application with DICOM support"                ON)
 option(Slicer_BUILD_DIFFUSION_SUPPORT           "Build application with Diffusion support"            OFF)
 option(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT    "Build application with ExtensionManager support"     ON)
@@ -188,18 +189,21 @@ list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR}/ImageSt
 #  )
 # list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
 
-# #SlicerIMSTK
-# set(extension_name "SlicerIMSTK")
-# set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
-# FetchContent_Populate(${extension_name}
-#  SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
-#  GIT_REPOSITORY https://github.com/KitwareMedical/SlicerIMSTK.git
-#  GIT_TAG        cd37cd73f853cf3cb09b9611d9cb715d5f84613c
-#  GIT_PROGRESS   1
-#  QUIET
-#  )
-# message(STATUS "Remote - ${extension_name} [OK]")
-# list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
+#SlicerIMSTK
+if(vpaw_USE_IMSTK)
+  set(extension_name "SlicerIMSTK")
+  set(${extension_name}_SOURCE_DIR "${CMAKE_BINARY_DIR}/${extension_name}")
+  FetchContent_Populate(${extension_name}
+   SOURCE_DIR     ${${extension_name}_SOURCE_DIR}
+   GIT_REPOSITORY https://github.com/KitwareMedical/SlicerIMSTK.git
+   GIT_TAG        cd37cd73f853cf3cb09b9611d9cb715d5f84613c
+   GIT_PROGRESS   1
+   QUIET
+   )
+  message(STATUS "Remote - ${extension_name} [OK]")
+  list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
+  include(${${extension_name}_SOURCE_DIR}/SuperBuildPrerequisites.cmake)
+endif()
 
 #SlicerSegmentEditorExtraEffects modules
 set(extension_name "SlicerSegmentEditorExtraEffects")
@@ -237,8 +241,6 @@ FetchContent_Populate(${extension_name}
  QUIET
  )
 list(APPEND Slicer_EXTENSION_SOURCE_DIRS ${${extension_name}_SOURCE_DIR})
-
-# include(${SlicerIMSTK_SOURCE_DIR}/SuperBuildPrerequisites.cmake)
 
 # Add Slicer sources
 add_subdirectory(${slicersources_SOURCE_DIR} ${slicersources_BINARY_DIR})


### PR DESCRIPTION
Add the `Endoscopy` and `AirwaySegmentation` modules and the `SlicerMorph` module's dependency, `MarkupsToModel`.  

One of the commits also adds IMSTK functionality and the next commit takes it away.  That way we have a history in case we want to do something similar later.  The functionality would add a `vpaw_USE_IMSTK` optional cmake variable that defaults to `OFF`, which will install IMSTK and its dependencies when set to `ON` This is supported as an option because IMSTK does not currently build on all platforms (C++ versioning issue; see Issue #38).  Including this module would enable the user and the internal API to take advantage of this module.