### PR TITLE
ENH: Update Slicer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer
-    GIT_TAG        516716c035743cd26364a7e7aefb72940d8abc8c # 2024-01-20
+    GIT_TAG        024b340baaa191968b6fc954b9f0e548adb40d6d # 2024-03-06
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
List of Slicer changes:

```
$ git shortlog 516716c03..024b340baa --no-merges
Andras Lasso (16):
      ENH: Update CTK to latest
      BUG: Fix deletion of last time point in a sequence
      BUG: Fix segment disappearing when sharing segment editor node between widgets
      ENH: Disable shadows in 3D views by default
      BUG: Fix loading of modules that depend on another extension
      ENH: Improve appearance of node information section in Data module
      BUG: Fix unrelated matrix elements overwritten in transform editor
      ENH: Add SegmentationGeometryLogic API to set reference image geometry
      BUG: Fix loading of empty segmentation (#7609)
      ENH: Make translations in Python scripts more robust
      BUG: Make volume rendering preset registration more robust
      ENH: Add API to access SSAO rendering pass in 3D views
      ENH: Improve vtkMRMLLayoutNode API
      BUG: Fix subject hierarchy consolidation after loading a scene
      BUG: Fixed saving of NRRD files of certain filenames
      ENH: Improve SubjectHierarchy API for UIDs

Andrey Fedorov (1):
      ENH: Update the list of supported formats

Aram (1):
      BUG: Fixed issue with adding new node after rename cancelation (#7598)

James Butler (1):
      COMP: Update python packages to latest

Jean-Christophe Fillion-Robin (13):
      ENH: Support dragging of the splashwindow just after clicking on it (#7532)
      ENH: Update CTK to backport PythonQt fixes & restore script compilation to pyc
      BUG: Ensure packaging of the latest d3dcompiler_47.dll for SlicerVirtualReality
      BUG: Update CTK to fix Qt designer crash at startup
      BUG: Fix qSlicerExtensionsManagerModelTest
      BUG: Ensure launcher scripts installed from wheels are accessible
      STYLE: Convert C++ source files from old-style "Whitesmiths" to "Allman" style
      STYLE: Add brace indentation style update to ignored list for git blame
      STYLE: Add missing semicolon after statement macros
      BUG: Skip creation of markups and transform interaction widget in VR window
      STYLE: Update CTK with source files converted to "Allman" indentation style (#7623)
      ENH: Support returning the result when executing Python from qSlicerWebWidget
      BUG: Remove obsolete Webkit-specific integration code from qSlicerWebWidget

Kyle Sunderland (7):
      ENH: Add interaction handle visualization for linear transform nodes (#7562)
      ENH: Add DICOM support for Multi-frame Grayscale Byte Secondary Capture Image
      ENH: Add finer control of 2D interaction handle axis display
      ENH: Clean up vtkMRMLLinearTransformsDisplayableManager implementation
      ENH: Add jump to handle action for interaction handles
      ENH: Add cancel action for interaction handles
      BUG: Fix issues caused by invalid Segmentation binary labelmap scalar types

Mujassim Bhaijamal (1):
      DOC: Fix segmentation example in script repository

Slicer Bot (1):
      ENH: Update Slicer.crt CA bundle

Steve Pieper (2):
      ENH: Update https support and add WebXR demo as transform controller
      DOC: Update outdated https link in WebServer code

dependabot[bot] (15):
      COMP: Bump github/codeql-action from 3.23.0 to 3.23.1
      COMP: Bump actions/upload-artifact from 4.1.0 to 4.2.0
      COMP: Bump actions/upload-artifact from 4.2.0 to 4.3.0
      COMP: Bump github/codeql-action from 3.23.1 to 3.23.2
      COMP: Bump github/codeql-action from 3.23.2 to 3.24.0
      COMP: Bump dorny/paths-filter from 2.11.1 to 3.0.0
      COMP: Bump peter-evans/create-pull-request from 5.0.2 to 6.0.0
      COMP: Bump pre-commit/action from 3.0.0 to 3.0.1
      COMP: Bump actions/upload-artifact from 4.3.0 to 4.3.1
      COMP: Bump github/codeql-action from 3.24.0 to 3.24.3
      COMP: Bump dorny/paths-filter from 3.0.0 to 3.0.1
      COMP: Bump github/codeql-action from 3.24.3 to 3.24.5
      COMP: Bump peter-evans/create-pull-request from 6.0.0 to 6.0.1
      COMP: Bump github/codeql-action from 3.24.5 to 3.24.6
      COMP: Bump dorny/paths-filter from 3.0.1 to 3.0.2

```