### PR TITLE
Update build instructions for Microsoft Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,15 +11,14 @@ The initial source files were created using [KitwareMedical/SlicerCustomAppTempl
 Prerequisites
 -------------
 
-* Microsoft Windows 7 or above recommended
+* Microsoft Windows 10 or above recommended
 
 * Supported Microsoft Visual Studio versions:
-    * Visual Studio 2015
-    * Visual Studio 2017
+    * Visual Studio 17 2022
 
-* [CMake](http://cmake.org/cmake/resources/software.html), version 3.11 or above
+* [CMake](http://cmake.org/cmake/resources/software.html), version 3.16.3 or above
 
-* Qt, version 5.10 or above
+* Qt, version 5.15.2 recommended
 
 * [Git](http://git-scm.com/downloads)
 
@@ -51,7 +50,7 @@ Note: use short source and build directory names to avoid the [maximum path leng
 
 Build
 -----
-Note: The build process will take approximately 3 hours.
+Note: The build process will take approximately 3 hours on a modern computer.
 
 <b>Option 1: CMake GUI and Visual Studio (Recommended)</b>
 
@@ -69,7 +68,7 @@ Note: The build process will take approximately 3 hours.
 cd C:\W\
 mkdir vR
 cd vR
-cmake -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=`C:/Qt/${QT_VERSION}/${COMPILER}/lib/cmake/Qt5 ..\v
+cmake -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=`C:/Qt/${QT_VERSION}/${COMPILER}/lib/cmake/Qt5 ..\v
 cmake --build . --config Release -- /maxcpucount:4
 ```
 
@@ -85,9 +84,9 @@ Install [NSIS 2](http://sourceforge.net/projects/nsis/files/)
 <b>Option 2: Command Line</b>
 
 1. Start the [Command Line Prompt](http://windows.microsoft.com/en-us/windows/command-prompt-faq)
-2. Build the `PACKAGE` target by typing the following commands:
+2. Build the `package` target by typing the following commands:
 
 ```bat
 cd C:\W\vR\Slicer-build
-cmake --build . --config Release --target PACKAGE
+cmake --build . --config Release --target package
 ```


### PR DESCRIPTION
Make several changes to `BUILD.md`.  It is not necessarily that these new minimum versions are strictly necessary in every case, but earlier versions are risky because it is unlikely that we'll do testing on those earlier versions.

- We have had trouble building with `Visual Studio 16 2019` due to VPAW now using a more modern commit of `3D Slicer` as the base code.  We update the supported version list to include only `Visual Studio 17 2022`.  (It is possible that `Visual Studio 16 2019` could be made to work, but I gave up after a while.)
- We update the minimum operating system version from `Microsoft Windows 7` to `Microsoft Windows 10`.
- We update the minimum required version for `CMake` to `3.16.3` from `3.11`.
- We update the recommended minimum version of `Qt` from `5.10` to `5.15.2`.
- `--target package` works.  (`--target PACKAGE` did not work for me at one point, though perhaps that was due to an unrelated bug.) 