### PR TITLE
BUG: Remove extraneous code and widgets from VPAWVisualizeOCT

### DIFF
--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -76,7 +76,7 @@ def registerSampleData():
     Add data sets to Sample Data module.
     """
     # It is always recommended to provide sample data for users to make it easy to try
-    # the module, but if no sample data is available then this method (and associated
+    # the module, but if no sample data are available then this method (and associated
     # startupCompeted signal connection) can be removed.
 
     pass
@@ -261,13 +261,13 @@ class VPAWModelWidget(
         else:
             self.ui.linkPediatricAirwayAtlasButton.toolTip = (
                 "Install is disabled; first select a valid source code directory for"
-                + " the Pediatric Airway Atlas"
+                " the Pediatric Airway Atlas"
             )
             self.ui.linkPediatricAirwayAtlasButton.enabled = False
 
         self.ui.VPAWRootDirectory.toolTip = (
             "Directory containing FilteredControlBlindingLogUniqueScanFiltered.xls,"
-            + " images/*, and landmarks/*."
+            " images/*, and landmarks/*."
         )
         self.ui.VPAWModelDirectory.toolTip = (
             "Directory containing file named like '116(158.10-38.AM.24.Mar).pth'"
@@ -283,7 +283,7 @@ class VPAWModelWidget(
         else:
             self.ui.runPediatricAirwayAtlasButton.toolTip = (
                 "Run is disabled; first select input/output root directory and models"
-                + " directory"
+                " directory"
             )
             self.ui.runPediatricAirwayAtlasButton.enabled = False
 
@@ -469,7 +469,7 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
         stopTime = time.time()
         logging.info(
             f"Pediatric Airway Atlas installation completed in {stopTime-startTime:.2f}"
-            + " seconds",
+            " seconds",
         )
         return response
 
@@ -500,7 +500,7 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
         except ImportError:
             slicer.util.errorDisplay(
                 f"Unable to find pediatric_airway_atlas.{import_name}\n"
-                + "Check the console for details.",
+                "Check the console for details.",
                 "Install Error",
             )
             return False
@@ -615,16 +615,14 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
         # self.convertCTScansToNRRD(vPAWRootDirectory)
         response = self.convertFCSVLandmarksToP3(
             vPAWRootDirectory, patientPrefix,
-        ) and self.runSegmentation(
-            vPAWRootDirectory, vPAWModelDirectory, patientPrefix,
-        )
+        ) and self.runSegmentation(vPAWRootDirectory, vPAWModelDirectory, patientPrefix)
         if response:
             slicer.util.infoDisplay("The pipeline has completed", "Pipeline ran")
 
         stopTime = time.time()
         logging.info(
             f"Pediatric Airway Atlas pipeline completed in {stopTime-startTime:.2f}"
-            + " seconds",
+            " seconds",
         )
         return response
 
@@ -655,11 +653,11 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                 except Exception:
                     slicer.util.errorDisplay(
                         "The run failed.  It may be that a non-blank patient prefix is"
-                        + " not supported by this version of pediatric_airway_atlas"
-                        + ".conversion_utils.generate_pixel_space_landmarks."
-                        + "  Please update pediatric_airway_atlas and try again."
-                        + "  Alternatively, it may be that you entered a patient prefix"
-                        + " that does not exist.",
+                        " not supported by this version of pediatric_airway_atlas"
+                        ".conversion_utils.generate_pixel_space_landmarks."
+                        "  Please update pediatric_airway_atlas and try again."
+                        "  Alternatively, it may be that you entered a patient prefix"
+                        " that does not exist.",
                         "Run Error",
                     )
                     return False
@@ -780,11 +778,11 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
                 except Exception:
                     slicer.util.errorDisplay(
                         "The run failed.  It may be that a non-blank patient prefix is"
-                        + " not supported by this version of pediatric_airway_atlas"
-                        + ".atlas_builder_configurable."
-                        + "  Please update pediatric_airway_atlas and try again."
-                        + "  Alternatively, it may be that you entered a patient prefix"
-                        + " that does not exist.",
+                        " not supported by this version of pediatric_airway_atlas"
+                        ".atlas_builder_configurable."
+                        "  Please update pediatric_airway_atlas and try again."
+                        "  Alternatively, it may be that you entered a patient prefix"
+                        " that does not exist.",
                         "Run Error",
                     )
                     return False

--- a/Modules/Scripted/VPAWModelOCT/VPAWModelOCT.py
+++ b/Modules/Scripted/VPAWModelOCT/VPAWModelOCT.py
@@ -73,7 +73,7 @@ def registerSampleData():
     Add data sets to Sample Data module.
     """
     # It is always recommended to provide sample data for users to make it easy to try
-    # the module, but if no sample data is available then this method (and associated
+    # the module, but if no sample data are available then this method (and associated
     # startupCompeted signal connection) can be removed.
 
     pass
@@ -240,7 +240,7 @@ class VPAWModelOCTWidget(
         else:
             self.ui.linkOCTSegButton.toolTip = (
                 "Install is disabled; first select a valid source code directory for"
-                + " the OCT Segmentation"
+                " the OCT Segmentation"
             )
             self.ui.linkOCTSegButton.enabled = False
 
@@ -435,7 +435,7 @@ class VPAWModelOCTLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogi
         stopTime = time.time()
         logging.info(
             f"OCT Segmentation installation completed in {stopTime-startTime:.2f}"
-            + " seconds",
+            " seconds",
         )
         return response
 
@@ -558,11 +558,7 @@ class VPAWModelOCTLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogi
         self.showInstalledModules(installed_modules)
         return True
 
-    def runOCTSeg(
-        self,
-        octSegDirectory,
-        vPAWOCTConfigFile,
-    ):
+    def runOCTSeg(self, octSegDirectory, vPAWOCTConfigFile):
         """
         Run the OCT Segmentation pipeline.
         Can be used without GUI widget.
@@ -597,8 +593,7 @@ class VPAWModelOCTLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogi
 
         stopTime = time.time()
         logging.info(
-            f"OCT Segmentation pipeline completed in {stopTime-startTime:.2f}"
-            + " seconds",
+            f"OCT Segmentation pipeline completed in {stopTime-startTime:.2f} seconds",
         )
         return response
 

--- a/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
+++ b/Modules/Scripted/VPAWVisualize/VPAWVisualize.py
@@ -108,7 +108,7 @@ def registerSampleData():
     Add data sets to Sample Data module.
     """
     # It is always recommended to provide sample data for users to make it easy to try
-    # the module, but if no sample data is available then this method (and associated
+    # the module, but if no sample data are available then this method (and associated
     # startupCompeted signal connection) can be removed.
 
     pass

--- a/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
+++ b/Modules/Scripted/VPAWVisualize/vpawvisualizelib/isosurfaces.py
@@ -1,6 +1,5 @@
-import vtk
-
 import slicer
+import vtk
 
 
 def isosurfaces_from_volume(

--- a/Modules/Scripted/VPAWVisualizeOCT/Resources/UI/VPAWVisualizeOCT.ui
+++ b/Modules/Scripted/VPAWVisualizeOCT/Resources/UI/VPAWVisualizeOCT.ui
@@ -75,14 +75,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="dataDirectoryLabel">
         <property name="text">
-         <string>Data directory</string>
+         <string>Data directory (model_path)</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="patientPrefixLabel">
+       <widget class="QLabel" name="imageIdLabel">
         <property name="text">
-         <string>Patient prefix</string>
+         <string>Image id</string>
         </property>
        </widget>
       </item>
@@ -94,7 +94,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="PatientPrefix"/>
+       <widget class="QLineEdit" name="ImageId"/>
       </item>
      </layout>
     </widget>
@@ -130,105 +130,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="QStackedWidget" name="computeIsosurfacesStackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QPushButton" name="computeIsosurfacesButton">
-         <property name="text">
-          <string>Compute Isosurfaces</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSpinBox" name="numberOfIsosurfaceValues">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>45</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>45</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Number of isosurfaces</string>
-         </property>
-         <property name="value">
-          <number>15</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page_2">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QProgressBar" name="computeIsosurfacesProgressBar">
-         <property name="cursor">
-          <cursorShape>WaitCursor</cursorShape>
-         </property>
-         <property name="value">
-          <number>24</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="segmentationOpacityLabel">
-       <property name="text">
-        <string>Segmentation Opacity</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="segmentationOpacitySlider">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="maximum">
-        <number>10</number>
-       </property>
-       <property name="singleStep">
-        <number>1</number>
-       </property>
-       <property name="pageStep">
-        <number>1</number>
-       </property>
-       <property name="value">
-        <number>3</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="invertedAppearance">
-        <bool>false</bool>
-       </property>
-       <property name="tickPosition">
-        <enum>QSlider::NoTicks</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">


### PR DESCRIPTION
Remove parts from `VPAWVisualizeOCT` that mimicked parts of `VPAWVisualize` but were not appropriate.  Support for the combination of 2-dimensional slices into a 3-dimensional volume can be added to `VPAWVisualizeOCT` once the combination is supported by the `uncbiag/OCTSeg` pipeline.

Also, modify the debug-output function `summary_repr` to optionally be less verbose.  Also, format code to respect what `ruff check` wants.

Although there is more to be done with `VPAWVisualizeOCT`, I am submitting this pull request so that these changes on my repository fork do not become stale.