### PR TITLE
BUG: Remove pyrender from dependency list

### DIFF
--- a/Modules/Scripted/VPAWModel/VPAWModel.py
+++ b/Modules/Scripted/VPAWModel/VPAWModel.py
@@ -429,7 +429,6 @@ class VPAWModelLogic(slicer.ScriptedLoadableModule.ScriptedLoadableModuleLogic):
             ("pandas", "pandas"),
             ("pydicom", "pydicom"),
             ("pyransac3d", "pyransac3d"),
-            ("pyrender", "pyrender"),
             ("pytorch_lightning", "pytorch_lightning"),
             ("rtree", "rtree"),
             ("ruffus", "ruffus"),


### PR DESCRIPTION
fixes vpaw "link to pediatric_airway_atlas` on linux

pyrender is never used by VPAW and importing it crashes due to pyglet's incompatibility with the linux2 display platform